### PR TITLE
Fix image filter bugs; prevent render of 'font' elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -1808,6 +1808,10 @@ var xmldom = require('xmldom');
 					}
 				}
 			}
+
+			this.render = function() {
+				// NO RENDER
+			};
 		}
 		svg.Element.font.prototype = new svg.Element.ElementBase;
 
@@ -2114,14 +2118,13 @@ var xmldom = require('xmldom');
 				// Decode base64 data
 				var buffer = new Buffer(data, 'base64');
 
-				// if png/jpeg, simply draw it
 				if(!isSvg) {
+					// if png/jpeg, simply draw it
 					renderBuffer(this, buffer);
-					return;
+				} else {
+					// if svg render it
+					renderSvg(this, buffer);
 				}
-
-				// if svg render it
-				renderSvg(this, buffer);
 			} else {
 
 				var isSvg = href.match(/\.svg$/)
@@ -2158,13 +2161,13 @@ var xmldom = require('xmldom');
 				ctx.restore();
 			}
 
-            this.getBoundingBox = function() {
-                var x = this.attribute('x').toPixels('x');
-                var y = this.attribute('y').toPixels('y');
-                var width = this.attribute('width').toPixels('x');
-                var height = this.attribute('height').toPixels('y');
-                return new svg.BoundingBox(x, y, x + width, y + height);
-            }
+			this.getBoundingBox = function() {
+				var x = this.attribute('x').toPixels('x');
+				var y = this.attribute('y').toPixels('y');
+				var width = this.attribute('width').toPixels('x');
+				var height = this.attribute('height').toPixels('y');
+				return new svg.BoundingBox(x, y, x + width, y + height);
+			}
 		}
 		svg.Element.image.prototype = new svg.Element.RenderedElementBase;
 
@@ -2409,7 +2412,9 @@ var xmldom = require('xmldom');
 
 				// apply filters
 				for (var i=0; i<this.children.length; i++) {
-					this.children[i].apply(tempCtx, 0, 0, width + 2*px, height + 2*py);
+					if (typeof this.children[i].apply == 'function') {
+						this.children[i].apply(tempCtx, 0, 0, width + 2*px, height + 2*py);
+					}
 				}
 
 				// render on me


### PR DESCRIPTION
Hello!  Thanks for porting canvg into Node.  Here are some changes I made to my local copy.  There are four changes.  In order of line numbers:

Lines 1811-1814 prevent the contents of the 'font' element from being rendered.  If an SVG has a font embedded directly inside the file, Canvg would have naively rendered every glyph of the font.  This is a change I made here that is not currently in upstream, although I might send a PR to upstream as well.

Lines 2117-2126 prevent returning out of the function upon reading a bitmap image.  The remainder of the function remains important, as it sets up tooling functions used by filter later.  This issue appears to have been introduced by the port to Node.

Lines 2161-2170 are fixing indentation.

Lines 2412-2417 are porting a fix from upstream.

How frequently do you merge upstream changes?  Since lines 2412-2417 (and potentially lines 1811-1814) are upstream changes, they might introduce merge conflicts next time you pull.
